### PR TITLE
날짜 계산

### DIFF
--- a/lib/DateCalculator.dart
+++ b/lib/DateCalculator.dart
@@ -2,7 +2,16 @@ class DateCalculator {
   int calcDate(DateCalculatorFormat to, DateCalculatorFormat from) {
     DateTime fromDate = DateTime(from.getYear(), from.getMonth(), from.getDay());
     DateTime toDate = DateTime(to.getYear(), to.getMonth(), to.getDay());
-    return toDate.difference(fromDate).inDays;
+
+    if(toDate.weekday == DateTime.saturday) {
+      toDate = toDate.add(const Duration(days: 2));
+    } else if (toDate.weekday == DateTime.sunday) {
+      toDate = toDate.add(const Duration(days: 1));
+    }
+
+    final range = toDate.difference(fromDate).inDays + 1; // 오늘 날짜 포함
+    if (range <= 1) return throw UnsupportedError("Range is too short.");
+    return range < 31 ? 31 : range;
   }
 }
 

--- a/lib/DateCalculator.dart
+++ b/lib/DateCalculator.dart
@@ -1,18 +1,27 @@
 class DateCalculator {
-  int calcDate(DateCalculatorFormat to, DateCalculatorFormat from) {
-    DateTime fromDate = DateTime(from.getYear(), from.getMonth(), from.getDay());
-    DateTime toDate = DateTime(to.getYear(), to.getMonth(), to.getDay());
+  late final Set<DateTime> _holidays;
 
-    if(toDate.weekday == DateTime.saturday) {
-      toDate = toDate.add(const Duration(days: 2));
-    } else if (toDate.weekday == DateTime.sunday) {
-      toDate = toDate.add(const Duration(days: 1));
+  DateCalculator(Set<DateCalculatorFormat> holidays) {
+    _holidays = holidays.map((format) => DateTime(format.getYear(), format.getMonth(), format.getDay())).toSet();
+  }
+
+  int calcDate(DateCalculatorFormat start, DateCalculatorFormat end) {
+    DateTime receiptDate = DateTime(start.getYear(), start.getMonth(), start.getDay());
+    DateTime maturityDate = DateTime(end.getYear(), end.getMonth(), end.getDay());
+
+    // 만기일이 주말이거나, 공휴일인 경우, 하루 더해준다.
+    while (_holidays.contains(maturityDate) || maturityDate.isWeekend) {
+      maturityDate = maturityDate.add(const Duration(days: 1));
     }
 
-    final range = toDate.difference(fromDate).inDays + 1; // 오늘 날짜 포함
+    final range = maturityDate.difference(receiptDate).inDays + 1; // 오늘 날짜 포함
     if (range <= 1) return throw UnsupportedError("Range is too short.");
     return range < 31 ? 31 : range;
   }
+}
+
+extension on DateTime {
+  bool get isWeekend => weekday == DateTime.saturday || weekday == DateTime.sunday;
 }
 
 abstract class DateCalculatorFormat {

--- a/lib/DateCalculator.dart
+++ b/lib/DateCalculator.dart
@@ -1,12 +1,12 @@
 class DateCalculator {
-  int calcDate(CalcableFormat to, {CalcableFormat? from}) {
-    DateTime fromDate = from != null ? DateTime(from.getYear(), from.getMonth(), from.getDay()) : DateTime.now();
+  int calcDate(DateCalculatorFormat to, DateCalculatorFormat from) {
+    DateTime fromDate = DateTime(from.getYear(), from.getMonth(), from.getDay());
     DateTime toDate = DateTime(to.getYear(), to.getMonth(), to.getDay());
     return toDate.difference(fromDate).inDays;
   }
 }
 
-abstract class CalcableFormat {
+abstract class DateCalculatorFormat {
   int getYear();
 
   int getMonth();

--- a/test/DateCalculator_test.dart
+++ b/test/DateCalculator_test.dart
@@ -9,45 +9,72 @@ import 'package:naranote/DateCalculator.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("8월 19일 부터 8월 20일은 1일 차이다.", () {
-    final dateCalc = DateCalculator();
+  final dateCalc = DateCalculator();
 
+  test("8월 19일 부터 8월 20일은 2일 차이다. 31일 이하이기 때문에 31이 나와야 한다.", () {
     const from = "2024-08-19";
     const to = "2024-08-20";
     final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
-    expect(dates, 1);
+    expect(dates, 31);
   });
 
   test("8월 18일 부터 8월 20일은 2일 차이다.", () {
-    final dateCalc = DateCalculator();
-
     const from = "2024-08-18";
     const to = "2024-08-20";
     final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
-    expect(dates, 2);
+    expect(dates, 31);
   });
 
-  test("같은날짜라면 0을 리턴한다.", () {
-    final dateCalc = DateCalculator();
-
+  test("같은날짜라면 Unsupported 에러가 발생한다.", () {
     const from = "2024-08-19";
     const to = "2024-08-19";
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
-    expect(dates, 0);
+    expect(() => dateCalc.calcDate(TestDate.from(to), TestDate.from(from)), throwsA(isA<UnsupportedError>()));
   });
 
-  test("to의 날짜가 오늘보다 이전이라면 -1을 리턴한다. 실제 계산이 되더라도 무조건 -1을 리턴한다.", () {
-    final dateCalc = DateCalculator();
-
+  test("to의 날짜가 오늘보다 이전이라면 Unsupported 에러가 발생한다.", () {
     const from = "2024-08-19";
     const to = "2023-08-19";
 
+    expect(() => dateCalc.calcDate(TestDate.from(to), TestDate.from(from)), throwsA(isA<UnsupportedError>()));
+  });
+
+  test("Given 2024.08.19, 2024.10.02, 기대값은 45일 이다.", () {
+    const from = "2024-08-19";
+    const to = "2024-10-02";
+
     final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
-    expect(dates, lessThan(-1));
+    expect(dates, 45);
+  });
+
+  test("Given 2024.08.19, 2024.10.04, 기대값은 47일 이다.", () {
+    const from = "2024-08-19";
+    const to = "2024-10-04";
+
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+
+    expect(dates, 47);
+  });
+
+  test("Given 2024.08.19, 2024.10.05(토요일), 기대값은 50일 이다. 보정 +2일", () {
+    const from = "2024-08-19";
+    const to = "2024-10-05";
+
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+
+    expect(dates, 50);
+  });
+
+  test("Given 2024.08.19, 2024.10.06(일요일), 기대값은 50일 이다. 보정 +1일", () {
+    const from = "2024-08-19";
+    const to = "2024-10-06";
+
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+
+    expect(dates, 50);
   });
 }
 

--- a/test/DateCalculator_test.dart
+++ b/test/DateCalculator_test.dart
@@ -9,12 +9,13 @@ import 'package:naranote/DateCalculator.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final dateCalc = DateCalculator();
+  final holidays = {TestDate.from("2024-08-15"), TestDate.from("2024-03-01")};
+  final dateCalc = DateCalculator(holidays);
 
   test("8월 19일 부터 8월 20일은 2일 차이다. 31일 이하이기 때문에 31이 나와야 한다.", () {
     const from = "2024-08-19";
     const to = "2024-08-20";
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
 
     expect(dates, 31);
   });
@@ -22,7 +23,7 @@ void main() {
   test("8월 18일 부터 8월 20일은 2일 차이다.", () {
     const from = "2024-08-18";
     const to = "2024-08-20";
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
 
     expect(dates, 31);
   });
@@ -31,21 +32,21 @@ void main() {
     const from = "2024-08-19";
     const to = "2024-08-19";
 
-    expect(() => dateCalc.calcDate(TestDate.from(to), TestDate.from(from)), throwsA(isA<UnsupportedError>()));
+    expect(() => dateCalc.calcDate(TestDate.from(from), TestDate.from(to)), throwsA(isA<UnsupportedError>()));
   });
 
   test("to의 날짜가 오늘보다 이전이라면 Unsupported 에러가 발생한다.", () {
     const from = "2024-08-19";
     const to = "2023-08-19";
 
-    expect(() => dateCalc.calcDate(TestDate.from(to), TestDate.from(from)), throwsA(isA<UnsupportedError>()));
+    expect(() => dateCalc.calcDate(TestDate.from(from), TestDate.from(to)), throwsA(isA<UnsupportedError>()));
   });
 
   test("Given 2024.08.19, 2024.10.02, 기대값은 45일 이다.", () {
     const from = "2024-08-19";
     const to = "2024-10-02";
 
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
 
     expect(dates, 45);
   });
@@ -54,7 +55,7 @@ void main() {
     const from = "2024-08-19";
     const to = "2024-10-04";
 
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
 
     expect(dates, 47);
   });
@@ -63,7 +64,7 @@ void main() {
     const from = "2024-08-19";
     const to = "2024-10-05";
 
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
 
     expect(dates, 50);
   });
@@ -72,9 +73,27 @@ void main() {
     const from = "2024-08-19";
     const to = "2024-10-06";
 
-    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
 
     expect(dates, 50);
+  });
+
+  test("Given 2024.07.01, 2024.08.15(광복절, 공휴일), 기대값은 47일 이다. 보정 +1일", () {
+    const from = "2024-07-01";
+    const to = "2024-08-15";
+
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
+
+    expect(dates, 47);
+  });
+
+  test("Given 2024.01.01, 2024.03.01(삼일절, 공휴일), 기대값은 64일 이다. 공휴일 + 1, 토요일 + 1, 일요일 + 1", () {
+    const from = "2024-01-01";
+    const to = "2024-03-01";
+    //단순 계산으로는 61일 이다. 다음 평일은 3월 4일이 된다.
+    final dates = dateCalc.calcDate(TestDate.from(from), TestDate.from(to));
+
+    expect(dates, 64);
   });
 }
 

--- a/test/DateCalculator_test.dart
+++ b/test/DateCalculator_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     const from = "2024-08-19";
     const to = "2024-08-20";
-    final dates = dateCalc.calcDate(from: TestDate.from(from), TestDate.from(to));
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
     expect(dates, 1);
   });
@@ -24,34 +24,34 @@ void main() {
 
     const from = "2024-08-18";
     const to = "2024-08-20";
-    final dates = dateCalc.calcDate(from: TestDate.from(from), TestDate.from(to));
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
     expect(dates, 2);
   });
 
-  test("같은날짜라면? 0이라고 리턴한다.", () {
+  test("같은날짜라면 0을 리턴한다.", () {
     final dateCalc = DateCalculator();
 
     const from = "2024-08-19";
     const to = "2024-08-19";
-    final dates = dateCalc.calcDate(from: TestDate.from(from), TestDate.from(to));
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
     expect(dates, 0);
   });
 
-  test("to의 날짜가 오늘보다 이전이라면 에러가 나을까 -1이 나을까, 이런경우 책임은 누구에게 있는가.", () {
+  test("to의 날짜가 오늘보다 이전이라면 -1을 리턴한다. 실제 계산이 되더라도 무조건 -1을 리턴한다.", () {
     final dateCalc = DateCalculator();
 
     const from = "2024-08-19";
     const to = "2023-08-19";
 
-    final dates = dateCalc.calcDate(from: TestDate.from(from), TestDate.from(to));
+    final dates = dateCalc.calcDate(TestDate.from(to), TestDate.from(from));
 
     expect(dates, lessThan(-1));
   });
 }
 
-class TestDate implements CalcableFormat {
+class TestDate implements DateCalculatorFormat {
   late final int _year;
   late final int _month;
   late final int _day;


### PR DESCRIPTION
날짜를 계산하는 DateCalculator 클래스 개발

DateCalculatorFormat 형식에 따라 calcDate에 메시지를 보내면 기간에 대한 결과를 얻을 수 있음

만기일이 공휴일이거나 주말일 경우 다음 평일까지 자동으로 더해서 결과를 알려줌

만약 계산 결과 기간이 31일 미만인 경우, 31일로 결과값을 리턴함.

만약 계산 결과 기간이 1 이하인 경우, UnssportedError 가 발생하며 메시지는 "Range is too short." 이다.

공휴일 정보는 Set으로 객체 초기화 시에 전달받아야함.
